### PR TITLE
feat: new macro (PA-2479: PA-2713)

### DIFF
--- a/transformations/macros/concatenate_currency.sql
+++ b/transformations/macros/concatenate_currency.sql
@@ -1,0 +1,10 @@
+{% macro concatenate_currency(attribute, parameter) %}
+
+{# Use the target.type to make the macro database specific when needed. #}
+{% if target.type == 'snowflake' %}
+    concat({{ attribute }}, ' {{ parameter }}')
+{% elif target.type == 'sqlserver' %}
+    concat({{ attribute }}, ' {{ parameter }}')
+{% endif %}
+
+{% endmacro %}

--- a/transformations/models/Multiple_databases_support.sql
+++ b/transformations/models/Multiple_databases_support.sql
@@ -16,8 +16,8 @@ Multiple_databases_support as (
         as "Price_converted",
         -- With a macro the code is more readable.
         {{ pm_utils.to_varchar('Invoices_input."Price"') }} as "Price_converted_with_macro",
-        -- Timestamp based on only a date attribute.
-        {{ pm_utils.timestamp_from_date('Invoices_input."Payment_due_date"') }} as "Payment_due_date_timestamp"
+        -- Implement your own macro when a macro is not available in pm-utils.
+        {{ concatenate_currency('Invoices_input."Price"', 'dollar') }} as "Price_with_currency"
     from Invoices_input
 )
 


### PR DESCRIPTION
- New macro is not generic and therefore a more stable example than datediff which will be removed in a different PR.
- Remove timestamp_from_date example which did not add anything.