### PR TITLE
DNA-9565 (DNA-9683) introduce schema_sources variable

### DIFF
--- a/.pipelines/azure-pipelines-transformations.yml
+++ b/.pipelines/azure-pipelines-transformations.yml
@@ -20,7 +20,7 @@ resources:
       endpoint: UiPath
       type: github
       name: UiPath/ProcessMining-framework-resources
-      ref: refs/tags/dbt_transformations.0.5.0
+      ref: refs/tags/dbt_transformations.0.5.1
 
     - repository: sqlfluffLinter
       endpoint: UiPath

--- a/transformations/dbt_project.yml
+++ b/transformations/dbt_project.yml
@@ -7,6 +7,8 @@ config-version: 2
 # This setting configures which "profile" dbt uses for this project.
 profile: 'devkit_connector'
 
+vars:
+
 # These configurations specify where dbt should look for different types of files.
 model-paths: ["models"]
 macro-paths: ["macros"]

--- a/transformations/dbt_project_sqlserver.yml
+++ b/transformations/dbt_project_sqlserver.yml
@@ -7,6 +7,8 @@ config-version: 2
 # This setting configures which "profile" dbt uses for this project.
 profile: 'devkit_connector'
 
+vars:
+
 # These configurations specify where dbt should look for different types of files.
 model-paths: ["models"]
 macro-paths: ["macros"]

--- a/transformations/models/schema/sources.yml
+++ b/transformations/models/schema/sources.yml
@@ -4,7 +4,7 @@ version: 2
 # You can refer to these sources in the models by using the {{ source() }} jinja function.
 sources:
   - name: sources
-    schema: "{{ target.schema }}"
+    schema: "{{ var('schema_sources', target.schema) }}"
 
     # List all source tables and implement tests on them.
     tables:


### PR DESCRIPTION
## Description
- add schema_sources variable to enable storing source data on a separate schema.
- add release notes + dbt project number.

## Release
- [ ] Direct release (`main`)
- [x] Merge to `dev` branch

Collect the work for release 0.9.0.

## Testing
### Testing checklist:
- [x] Works on Automation Suite / SQL Server
- [x] Works on Automation Cloud / Snowflake

### Did you update?
- [x] End-to-end test
nothing to update.
- [x] Version number in both `dbt_project` files
- [x] Release notes
- [x] pm-utils
